### PR TITLE
Rps rules w cards

### DIFF
--- a/src/generic_code/cards.py
+++ b/src/generic_code/cards.py
@@ -44,8 +44,14 @@ class Card:
             self.block_damage = block_damage
         """
         self.type = card_type
-        self.damage = damage
-        self.speed = speed
+        self.damage = int(damage)
+        self.speed = int(speed)
+
+    def __repr__(self):
+        return f"Card {self.type}-S{self.speed}-D{self.damage}"
+
+    def __str__(self):
+        return f"Card {self.type}-S{self.speed}-D{self.damage}"
 
     def __eq__(self, other):
         if isinstance(other, Card):

--- a/src/generic_code/deck.py
+++ b/src/generic_code/deck.py
@@ -6,7 +6,7 @@ from typing import List, Union, Any
 from collections.abc import MutableSequence
 
 
-class Deck(cards, MutableSequence, ABC):
+class Deck(MutableSequence, ABC):
     """
     Class for containing cards and card operations.
     A deck is a composition of between 0 to 52 cards.

--- a/src/rps/rps_deck.py
+++ b/src/rps/rps_deck.py
@@ -3,8 +3,11 @@ from itertools import product
 from copy import deepcopy
 from typing import List
 
+from src.generic_code.cards import Card
+
 rps_cards: List[str] = [
-    flavor + str(size) for flavor, size in product("RPS", [1, 2, 3])
+    Card(str(size), str(size), flavor)
+    for flavor, speed, damage in product("ADT", [1, 2, 3], [1, 2, 3])
 ]
 
 

--- a/src/rps/rps_rules.py
+++ b/src/rps/rps_rules.py
@@ -69,5 +69,3 @@ def generate_rps_payoff_lookup():
             }
 
     return pay_off_matrix
-
-print(sorted("DA")) == "AD")

--- a/src/rps/rps_rules.py
+++ b/src/rps/rps_rules.py
@@ -5,37 +5,37 @@ def determine_suit_winner(left_suit, right_suit):
     # Assumes that it is called with different suites, responsibility lies
     # with the caller
 
-    if left_suit == "R":
+    if left_suit == "T":
         # Rock beats Scissors
-        if right_suit == "S":
+        if right_suit == "D":
             return "left"
         # Rock loses to paper
-        elif right_suit == "P":
+        elif right_suit == "A":
             return "right"
-    elif left_suit == "P":
+    elif left_suit == "A":
         # Paper covers rock
-        if right_suit == "R":
+        if right_suit == "T":
             return "left"
         # Paper gets cut by scissors
-        elif right_suit == "S":
+        elif right_suit == "D":
             return "right"
-    elif left_suit == "S":
+    elif left_suit == "D":
         # Sciccor gets crushed by rock
-        if right_suit == "R":
+        if right_suit == "T":
             return "right"
         # Paper cuts scissor
-        elif right_suit == "P":
+        elif right_suit == "A":
             return "left"
 
 
 def determine_score(winner, left_rank, right_rank):
 
     if winner == "left":
-        left_score = 4 - left_rank
+        left_score = left_rank
         right_score = 0
     elif winner == "right":
         left_score = 0
-        right_score = 4 - right_rank
+        right_score = right_rank
     else:  # Draw
         left_score = 0
         right_score = 0
@@ -45,22 +45,21 @@ def determine_score(winner, left_rank, right_rank):
 
 def determine_rps_outcome(left_card, right_card):
 
-    left_suit = left_card[0]
-    right_suit = right_card[0]
-    left_rank = int(left_card[1])
-    right_rank = int(right_card[1])
+    left_speed = left_card.speed
+    right_speed = right_card.speed
 
     if left_suit != right_suit:
-        winner = determine_suit_winner(left_suit, right_suit)
-    elif left_rank > right_rank:
+        winner = determine_suit_winner(left_card.type, right_card.type)
+
+    elif left_speed > right_speed:
         winner = "left"
-    elif left_rank < right_rank:
+    elif left_speed < right_speed:
         winner = "right"
     else:
         winner = "draw"
 
     left_score, right_score = determine_score(
-        winner=winner, left_rank=left_rank, right_rank=right_rank
+        winner=winner, left_rank=left_card.damage, right_rank=right_card.damage
     )
 
     return winner, left_score, right_score
@@ -71,9 +70,7 @@ def generate_rps_payoff_lookup():
     pay_off_matrix = {}
     for left_card in rps_cards:
         for right_card in rps_cards:
-            winner, left_score, right_score = determine_rps_outcome(
-                left_card, right_card
-            )
+            winner, left_score, right_score = determine_rps_outcome(left_card, right_card)
             score_diff = left_score - right_score
             pay_off_matrix[(left_card, right_card)] = {
                 "left": score_diff,

--- a/src/rps/rps_rules.py
+++ b/src/rps/rps_rules.py
@@ -7,6 +7,9 @@ def determine_suit_winner(left_suit, right_suit, order=["left", "right"]):
     if left_suit == right_suit:
         return "draw"
 
+    if "".join(sorted(left_suit + right_suit)) == "BD":
+        return "draw"
+
     if left_suit < right_suit:
         if left_suit == "A" and right_suit == "T":
             return order[0]
@@ -66,3 +69,5 @@ def generate_rps_payoff_lookup():
             }
 
     return pay_off_matrix
+
+print(sorted("DA")) == "AD")

--- a/src/rps/rps_rules.py
+++ b/src/rps/rps_rules.py
@@ -1,31 +1,19 @@
 from src.rps.rps_deck import rps_cards
 
 
-def determine_suit_winner(left_suit, right_suit):
+def determine_suit_winner(left_suit, right_suit, order=["left", "right"]):
     # Assumes that it is called with different suites, responsibility lies
     # with the caller
+    if left_suit == right_suit:
+        return "draw"
 
-    if left_suit == "T":
-        # Rock beats Scissors
-        if right_suit == "D":
-            return "left"
-        # Rock loses to paper
-        elif right_suit == "A":
-            return "right"
-    elif left_suit == "A":
-        # Paper covers rock
-        if right_suit == "T":
-            return "left"
-        # Paper gets cut by scissors
-        elif right_suit == "D":
-            return "right"
-    elif left_suit == "D":
-        # Sciccor gets crushed by rock
-        if right_suit == "T":
-            return "right"
-        # Paper cuts scissor
-        elif right_suit == "A":
-            return "left"
+    if left_suit < right_suit:
+        if left_suit == "A" and right_suit == "T":
+            return order[0]
+        return order[1]
+
+    else:
+        return determine_suit_winner(right_suit, left_suit, order[::-1])
 
 
 def determine_score(winner, left_rank, right_rank):
@@ -45,18 +33,13 @@ def determine_score(winner, left_rank, right_rank):
 
 def determine_rps_outcome(left_card, right_card):
 
-    left_speed = left_card.speed
-    right_speed = right_card.speed
+    winner = determine_suit_winner(left_card.type, right_card.type)
 
-    if left_suit != right_suit:
-        winner = determine_suit_winner(left_card.type, right_card.type)
-
-    elif left_speed > right_speed:
-        winner = "left"
-    elif left_speed < right_speed:
-        winner = "right"
-    else:
-        winner = "draw"
+    if winner == "draw":
+        if left_card.speed > right_card.speed:
+            winner = "left"
+        elif left_card.speed < right_card.speed:
+            winner = "right"
 
     left_score, right_score = determine_score(
         winner=winner, left_rank=left_card.damage, right_rank=right_card.damage
@@ -70,7 +53,9 @@ def generate_rps_payoff_lookup():
     pay_off_matrix = {}
     for left_card in rps_cards:
         for right_card in rps_cards:
-            winner, left_score, right_score = determine_rps_outcome(left_card, right_card)
+            winner, left_score, right_score = determine_rps_outcome(
+                left_card, right_card
+            )
             score_diff = left_score - right_score
             pay_off_matrix[(left_card, right_card)] = {
                 "left": score_diff,


### PR DESCRIPTION
# Card

Small improvements to the Card class:
- add __str__, __repr__: "Card {self.type}-S{self.speed}-D{self.damage}".
- Fixing (?) Deck: don't think the deck should be a child class of Cards.
- Changing RPS to TAD (Throw, Attack, Dodge).
- Implement Card in rps_cards.
- Changing the rules to implement speed, damage.

# determine_suit_winner

For our current RPS implementation:
> A<D<T
> Attack loses to Dodge loses to Throw
> Throw loses to Attack

Therefore comparing strings suffices for resolution. 

Note also that:
> A<B<T
> As above, but Block instead of Dodge

Implementing the relationship between Dodge and Block is all that is missing. Currently defined as a draw.